### PR TITLE
Get Reviews in a Different Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ API method that gets reviews in a different language outputs in this format. Not
 "id": video id
 "title": title of video
 "description": description of video
+
+PLEASE NOTE: Putting in just a proper noun will oftentimes give a search result in your native language due to the nature of YouTube's algorithm. For example, "harry potter" will likely just give you English search results. To fix this, try searching "harry potter review" instead. Languages that don't use the latin alphabet, such as Chinese or Russian, will not have this issue.

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, HTTPException
 from typing import List, Dict
-from youtube import search_movie_reviews, get_video_description
+from youtube import search_movie_reviews, get_video_description, search_movie_reviews_in_language
 
 app = FastAPI()
 
@@ -27,5 +27,14 @@ async def video_description(video_id: str):
             return {'description': description}
         else:
             raise HTTPException(status_code=404, detail='Description not found')
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+# Get reviews in a different language method
+@app.get('/moviereviews/{language}/{movie_name}', response_model=List[dict])
+async def get_movie_reviews_in_language(language: str, movie_name: str):
+    try:
+        translated_reviews = search_movie_reviews_in_language(language, movie_name)
+        return translated_reviews
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/test_main.py
+++ b/test_main.py
@@ -45,3 +45,23 @@ def test_video_description_no_description():
     # Assert the response status code and content
     assert response.status_code == 200
     assert response.json() == {'description': 'Description not found.'}
+
+@pytest.fixture
+def mock_search_movie_reviews_in_language(mocker):
+    mock = mocker.patch('main.search_movie_reviews_in_language', autospec=True)
+    mock.return_value = [
+        {
+            'id': 'video_id_1',
+            'title': 'Review 1',
+            'description': 'Description of review 1'
+        }
+    ]
+    return mock
+
+def test_get_movie_reviews_in_language(mock_search_movie_reviews_in_language):
+    language = 'es'
+    movie_name = 'test_movie'
+    response = client.get(f'/moviereviews/{language}/{movie_name}')
+    assert response.status_code == 200
+    assert response.json() == mock_search_movie_reviews_in_language.return_value
+    mock_search_movie_reviews_in_language.assert_called_once_with(language, movie_name)

--- a/test_youtube.py
+++ b/test_youtube.py
@@ -1,6 +1,6 @@
 import pytest
 from googleapiclient.discovery import build
-from youtube import search_movie_reviews, get_video_description
+from youtube import search_movie_reviews, get_video_description, search_movie_reviews_in_language
 
 def test_search_movie_reviews(mocker):
     # Mock the build function to return a mock object
@@ -41,3 +41,29 @@ def test_get_video_description_no_description():
 
     # Assert that the description is empty
     assert description == 'Description not found.'
+
+def test_search_movie_reviews_in_language(mocker):
+    # Mock the build function to return a mock object
+    mock_translate_build = mocker.patch('googleapiclient.discovery.build')
+
+    # Mock for the YouTube API response with 10 items
+    youtube_response = {
+        'items': [
+            {
+                'id': {'videoId': f'video{i}'},
+                'snippet': {
+                    'title': f'Review {i}',
+                    'description': f'Description of review {i}'
+                }
+            } for i in range(10)  # Generating 10 items for the mock response
+        ]
+    }
+
+    # Mock the execute method to return the youtube_response
+    mock_translate_build().search().list().execute.return_value = youtube_response
+
+    # Call search_movie_reviews function with a test query
+    results = search_movie_reviews_in_language('es', 'Harry Potter')
+
+    # Assert the expected outcomes from the function
+    assert len(results) == 10  # Now it checks if ten results are returned


### PR DESCRIPTION
In youtube.py: Created a ‘search_movie_reviews_in_language’ method that takes a language in ISO 639-1 two letter language codes as well as a movie title. The method translates the movie title into the specified language and returns the results in the same output format as the ‘search_movie_reviews’ method.

In main.py: Created an API method that uses the ‘search_movie_reviews_in_language’ method to output the id, title, and description of 10 search results for the movie in the desired language.

In test_youtube.py: Created a test method ‘test_search_movie_reviews_in_language’ that utilizes mocker to generate items for mock response and execute method for youtube response. The method passes if 10 results are returned.

In test_main.py: Created a test method ‘test_get_movie_reviews_in_language’ that uses a pytest fixture and mocker to check the ‘get_movie_reviews_in_language’ API method. The test passes if status code 200 is returned and if there is a return value from a language and movie name combination.

Updated README.md for clarification on language output regarding proper nouns.

Issue #5