### PR TITLE
Get reviews in a different language not properly translating proper nouns

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,5 +82,3 @@ API method that gets reviews in a different language outputs in this format. Not
 "id": video id
 "title": title of video
 "description": description of video
-
-PLEASE NOTE: Putting in just a proper noun will oftentimes give a search result in your native language due to the nature of YouTube's algorithm. For example, "harry potter" will likely just give you English search results. To fix this, try searching "harry potter review" instead. Languages that don't use the latin alphabet, such as Chinese or Russian, will not have this issue.

--- a/youtube.py
+++ b/youtube.py
@@ -55,15 +55,16 @@ def search_movie_reviews_in_language(language, movie_name):
     translate_request = translate.translations().list(
         source='en',
         target=language,
-        q=[movie_name]
+        q=[movie_name, 'review']
     )
     translate_response = translate_request.execute()
     translated_movie_name = translate_response['translations'][0]['translatedText']
+    translated_review_keyword = translate_response['translations'][1]['translatedText']
 
     youtube = build('youtube', 'v3', developerKey=YOUTUBE_API_KEY)
     search_request = youtube.search().list(
         part='snippet',
-        q=f'{translated_movie_name} review',
+        q=f'{translated_movie_name} {translated_review_keyword}',
         type='video',
         maxResults=10,
         order='relevance',


### PR DESCRIPTION
Translation API method was not properly translating proper nouns. This was because the word "review" wasn't being translated. I fixed this by modifying our translation request in our method in youtube.py to include a second translated keyword, which is just the word "review". 

I also updated the README.md accordingly.